### PR TITLE
 Updated searchForInLanguages(). 

### DIFF
--- a/src/system/modules/metamodelsattribute_translatedtags/MetaModelAttributeTranslatedTags.php
+++ b/src/system/modules/metamodelsattribute_translatedtags/MetaModelAttributeTranslatedTags.php
@@ -322,7 +322,7 @@ class MetaModelAttributeTranslatedTags extends MetaModelAttributeTags implements
 		$strColNameId = $this->get('tag_id');
 		$strColNameLangCode = $this->get('tag_langcolumn');
 		$strColumn = $this->get('tag_column');
-        $strColAlias = $this->get('tag_alias') ? $this->get('tag_alias') : $strColNameId;
+		$strColAlias = $this->get('tag_alias') ? $this->get('tag_alias') : $strColNameId;
         
 		$objFilterRule = new MetaModelFilterRuleSimpleQuery(
 			sprintf('SELECT item_id FROM tl_metamodel_tag_relation WHERE value_id IN (SELECT DISTINCT %1$s FROM %2$s WHERE %3$s LIKE ? OR %6$s LIKE ?%4$s) AND att_id = %5$s',
@@ -331,7 +331,7 @@ class MetaModelAttributeTranslatedTags extends MetaModelAttributeTags implements
 				$strColumn,     //3
 				$arrLanguages ? sprintf(' AND %s IN (\'%s\')',$strColNameLangCode,implode('\',\'', $arrLanguages)) : '',    //4
 				$this->get('id'),   //5
-                $strColAlias    //6
+				$strColAlias    //6
 			),
 			$arrParams,
 			'item_id'


### PR DESCRIPTION
Now matching aliases will also be found (like in MetamodelAttribute_translatedSelect)
